### PR TITLE
Convert divs to buttons

### DIFF
--- a/src/shared/modals/ModalHeader.js
+++ b/src/shared/modals/ModalHeader.js
@@ -7,7 +7,9 @@ const ModalHeader = (props) => {
   return (
     <div className="modal__header">
       <span>{title}</span>
-      <Icon onClick={onClose} icon={'close'} />
+      <button onClick={onClose}>
+        <Icon icon={'close'} />
+      </button>
     </div>
   )
 }

--- a/src/shared/modals/custom-filter/FilterFooter.js
+++ b/src/shared/modals/custom-filter/FilterFooter.js
@@ -11,10 +11,15 @@ const FilterFooter = (props) => {
 
   // Apply button only clickable when at least one row and column are checked
   const renderApply = () => {
-    return (checkedRows.length > 0 && checkedColumns.length) > 0 ? (
-      <button onClick={applyFilters}>Apply</button>
-    ) : (
-      <div>Apply</div>
+    let isDisabled = true
+
+    if (checkedRows.length > 0 && checkedColumns.length > 0) {
+      isDisabled = false
+    }
+    return (
+      <button onClick={applyFilters} disabled={isDisabled}>
+        Apply
+      </button>
     )
   }
 
@@ -32,10 +37,10 @@ const FilterFooter = (props) => {
 
   return (
     <div className="modal__footer">
-      <div onClick={handleResetFilters}>
+      <button onClick={handleResetFilters}>
         <Icon onClick={null} icon={'reset'} />
-        <span>Reset all filters</span>
-      </div>
+        Reset all filters
+      </button>
       {renderApply()}
       {renderRowWarning()}
       {renderColumnWarning()}

--- a/src/shared/site-config/SocialShare.js
+++ b/src/shared/site-config/SocialShare.js
@@ -37,9 +37,9 @@ const SocialShare = () => {
         </a>
       </li>
       <li className="menu-item">
-        <div onClick={() => window.print()}>
+        <button onClick={() => window.print()}>
           <Icon onClick={null} icon={'print'} />
-        </div>
+        </button>
       </li>
     </ul>
   )

--- a/src/shared/table/HeaderCell.js
+++ b/src/shared/table/HeaderCell.js
@@ -15,27 +15,27 @@ const HeaderCell = (props) => {
   return name === 'Categories' ? (
     <th className="table__header-cell">Categories</th>
   ) : (
-      <th className="table__header-cell">
-        <div className="header-cell__title" onClick={handleClick}>
-          <span className="header-cell__framework">{name}</span>
-          <span className="header-cell__icon">
-            <Icon handleClick={null} icon={'info'} />
-          </span>
-        </div>
-        <div className="header-cell__org">{organization}</div>
-        <div className="header-cell__doc">
-          <a
-            className="header-cell__doc-link"
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Icon onClick={null} icon={'external_link'} />
-            Original Document
+    <th className="table__header-cell">
+      <button className="header-cell__title" onClick={handleClick}>
+        <span className="header-cell__framework">{name}</span>
+        <span className="header-cell__icon">
+          <Icon handleClick={null} icon={'info'} />
+        </span>
+      </button>
+      <div className="header-cell__org">{organization}</div>
+      <div className="header-cell__doc">
+        <a
+          className="header-cell__doc-link"
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Icon onClick={null} icon={'external_link'} />
+          Original Document
         </a>
-        </div>
-      </th>
-    )
+      </div>
+    </th>
+  )
 }
 
 export default HeaderCell

--- a/src/shared/table/TableCell.js
+++ b/src/shared/table/TableCell.js
@@ -25,9 +25,9 @@ const TableCell = (props) => {
 
   const renderOriginalLang = () => {
     return catObj.original_lang !== '' ? (
-      <div className="cell__orig-lang" onClick={handleClick}>
+      <button className="cell__orig-lang" onClick={handleClick}>
         View Original Language
-      </div>
+      </button>
     ) : null
   }
 


### PR DESCRIPTION
I've gone through and converted a handful of `<div>` tags that had onClick handlers attached them to buttons. Buttons are the appropriate, semantic HTML element for the intended functionality (user clicks to trigger interactivity of some kind). Changing them to buttons adds in the extra bit of accessibility that you don't get if you use a div instead, like being able to tab and use your keyboard to activate them.

I also updated the "Apply" functionality in the filter so that it is always a button. Instead of switching it to a `<div>` when to disable it, we should use the disabled property instead.