### PR TITLE
Update tags to use semantic tags

### DIFF
--- a/src/shared/modals/FrameworkModal.js
+++ b/src/shared/modals/FrameworkModal.js
@@ -29,7 +29,7 @@ const FrameworkModal = () => {
   }
 
   return frameModalStatus ? (
-    <div className="modal">
+    <aside className="modal">
       <ModalHeader title={name} onClose={onClose} />
       <div className="modal__content">
         <div>ORGANIZATION</div>
@@ -55,7 +55,7 @@ const FrameworkModal = () => {
         ))}
       </div>
       <ModalFooter link={url} />
-    </div>
+    </aside>
   ) : null
 }
 

--- a/src/shared/modals/LangModal.js
+++ b/src/shared/modals/LangModal.js
@@ -20,7 +20,7 @@ const LangModal = () => {
   }
 
   return langModalStatus ? (
-    <div className="modal">
+    <aside className="modal">
       <ModalHeader title={'Original Language'} onClose={onClose} />
       <div className="modal__content">
         <div>FRAMEWORK</div>
@@ -31,7 +31,7 @@ const LangModal = () => {
         <div dangerouslySetInnerHTML={createMarkup(original_lang)} />
       </div>
       <ModalFooter link={link} />
-    </div>
+    </aside>
   ) : null
 }
 

--- a/src/shared/modals/ModalFooter.js
+++ b/src/shared/modals/ModalFooter.js
@@ -5,7 +5,7 @@ const ModalFooter = (props) => {
   const { link } = props
 
   return (
-    <div className="modal__footer">
+    <footer className="modal__footer">
       <a
         href={link}
         alt="original document"
@@ -15,7 +15,7 @@ const ModalFooter = (props) => {
         Original Framework Document
         <Icon onClick={null} icon={'external_link'} />
       </a>
-    </div>
+    </footer>
   )
 }
 

--- a/src/shared/modals/ModalHeader.js
+++ b/src/shared/modals/ModalHeader.js
@@ -5,10 +5,10 @@ const ModalHeader = (props) => {
   const { title, onClose } = props
 
   return (
-    <div className="modal__header">
+    <header className="modal__header">
       <span>{title}</span>
       <Icon onClick={onClose} icon={'close'} />
-    </div>
+    </header>
   )
 }
 

--- a/src/shared/site-config/Footer.js
+++ b/src/shared/site-config/Footer.js
@@ -14,8 +14,8 @@ const Footer = () => {
 
   return (
     <footer className="site-footer">
-      <section className="site-footer__explanation">
-        <div className="site-footer__title">Methodology</div>
+      <section id="methodology" className="site-footer__explanation">
+        <h2 className="site-footer__title">Methodology</h2>
         <div className="site-footer__info">
           <p className="site-footer__methodology">{methodology}</p>
           <p className="site-footer__prog-desc">{program_description}</p>
@@ -80,7 +80,6 @@ const Footer = () => {
             1616 Rhode Island Avenue, NW Washington, DC 20036
           </address>
         </div>
-        <a name="Methodology" href="#" alt="Methodology redirect"></a>
         <button
           aria-label="back to top"
           className="back-to-top sticky"

--- a/src/shared/site-config/Header.js
+++ b/src/shared/site-config/Header.js
@@ -34,9 +34,7 @@ const Header = () => {
             />
           </a>
         </div>
-        <div className="site-header__nav" role="navigation">
-          <SocialShare />
-        </div>
+        <SocialShare />
       </section>
       <section className="site-header__title">
         <div className="site-header__program">{program_name}</div>

--- a/src/shared/site-config/Header.js
+++ b/src/shared/site-config/Header.js
@@ -45,7 +45,7 @@ const Header = () => {
           <p>{intro_paragraph}</p>
         </div>
         <section className="site-header__actions">
-          <a className="site-header__methodology" href="#Methodology">
+          <a className="site-header__methodology" href="#methodology">
             Methodology
             <Icon onClick={null} icon={'arrow'} />
           </a>

--- a/src/shared/site-config/SocialShare.js
+++ b/src/shared/site-config/SocialShare.js
@@ -3,8 +3,8 @@ import Icon from './Icon'
 
 const SocialShare = () => {
   return (
-    <ul className="site-header__nav-menu">
-      <li className="menu-item">
+    <ul className="share">
+      <li className="share__item">
         <a
           href={`https://www.facebook.com/sharer.php?u=${window.location.href}`}
           rel="noopener noreferrer"
@@ -13,7 +13,7 @@ const SocialShare = () => {
           <Icon onClick={null} icon={'facebook'} />
         </a>
       </li>
-      <li className="menu-item">
+      <li className="share__item">
         <a
           href={`https://twitter.com/intent/tweet?url=${window.location.href}&amp;via=CSIS&amp;related=CSIS`}
           rel="noopener noreferrer"
@@ -22,7 +22,7 @@ const SocialShare = () => {
           <Icon onClick={null} icon={'twitter'} />
         </a>
       </li>
-      <li className="menu-item">
+      <li className="share__item">
         <a
           href={`https://www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&source=CSIS`}
           rel="noopener noreferrer"
@@ -31,12 +31,12 @@ const SocialShare = () => {
           <Icon onClick={null} icon={'linkedin'} />
         </a>
       </li>
-      <li className="menu-item">
+      <li className="share__item">
         <a href={`mailto:techpolicy@csis.org?subject=${document.title}`}>
           <Icon onClick={null} icon={'email'} />
         </a>
       </li>
-      <li className="menu-item">
+      <li className="share__item">
         <div onClick={() => window.print()}>
           <Icon onClick={null} icon={'print'} />
         </div>

--- a/src/shared/table/TableContainer.js
+++ b/src/shared/table/TableContainer.js
@@ -4,10 +4,10 @@ import DataTable from './DataTable'
 
 const TableContainer = (props) => {
   return (
-    <div className="table">
+    <main className="table">
       <TableOptions />
       <DataTable headers={props.headers} rows={props.rows} />
-    </div>
+    </main>
   )
 }
 


### PR DESCRIPTION
I've updated several of the components to use more appropriate, semantic HTML elements inside of `<div>`s.

I also removed the navigation role from the social share element because that designation should be used for more in-site navigation, such as between different pages. I think this one is debatable - I did a bit of Googling and there's no clear-cut answer on this, but most sources I checked erred on the site of not including stuff like social media sharing as a part of this. However, **if** they did qualify as navigation, it would be more appropriate to wrap it inside of a `<nav>` tag.

I removed the empty `<a>` tag with the methodology id, and instead assigned the id to the methodology section. Anchor links don't require jumping to another link, so it's best practice to assign the id to either a heading or the containing section instead of including an empty `<a>` tag.