### PR TITLE
Rename the calculate-rem function to just rem()

### DIFF
--- a/src/scss/abstracts/_functions.scss
+++ b/src/scss/abstracts/_functions.scss
@@ -7,7 +7,7 @@
 =================================*/
 
 $browser-context: 16px;
-@function calculate-rem($size) {
+@function rem($size) {
   $rem-size: $size / $browser-context;
   @return #{$rem-size}rem;
 }

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -1,4 +1,5 @@
 @use 'variables' as *;
+@use 'functions' as *;
 @use 'sass:map';
 
 /*=================================
@@ -44,5 +45,5 @@
 // Rem output with px fallback
 @mixin font-size($size) {
   font-size: $size; //Fallback in px
-  font-size: calculate-rem($size);
+  font-size: rem($size);
 }

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -5,7 +5,7 @@
 
   &__header-cell {
     min-width: 250px;
-    padding: calculate-rem(24px);
+    padding: rem(24px);
     @extend %table__header;
     text-align: left;
     vertical-align: top;
@@ -13,13 +13,13 @@
 
     &:first-of-type {
       min-width: 300px;
-      padding-left: calculate-rem(40px);
+      padding-left: rem(40px);
       color: $color__white-175;
       border-right: solid 1px #2a72a3;
     }
 
     &:last-of-type {
-      padding-right: calculate-rem(40px);
+      padding-right: rem(40px);
     }
 
     &-title {
@@ -44,7 +44,7 @@
     }
 
     &-org {
-      margin-bottom: calculate-rem(8px);
+      margin-bottom: rem(8px);
     }
 
     &-doc-link {
@@ -55,17 +55,17 @@
 
   &__cell {
     min-width: 250px;
-    padding: calculate-rem(24px);
+    padding: rem(24px);
     vertical-align: top;
     background-color: $color__white;
 
     &:first-of-type {
       min-width: 300px;
-      padding-left: calculate-rem(40px);
+      padding-left: rem(40px);
     }
 
     &:last-of-type {
-      padding-right: calculate-rem(40px);
+      padding-right: rem(40px);
       border-right: solid 1px #dfe3e8;
       box-shadow: 3px 6px 8px 0 rgba(164, 164, 164, 0.5);
     }


### PR DESCRIPTION
In hindsight, I've realized we could probably just do `rem(8px)` to make things a little less verbose...