### PR TITLE
Add container classes to components

### DIFF
--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -45,3 +45,6 @@ $breakpoints: (
   'medium': 37.5em,
   'large': 64em
 );
+
+$size__container-max-width: 1200px;
+$size__container-max-width--inner: 980px;

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -40,19 +40,8 @@ $font__expo: ExpoSerifPro, serif;
 
 /*----------  Structure  ----------*/
 
-$sizes__default: ('small', 'medium', 'large', 'xlarge');
-
 $breakpoints: (
-  // 0
-    'small': 0,
-  // 600px
-    'medium': 37.5em,
-  // 900px
-    'large': 56.25em,
-  // 1050px
-    'large-2': 68.75em,
-  // 1280px
-    'xlarge': 80em,
-  // 1440px
-    'xlarge-2': 90em
+  'small': 0,
+  'medium': 37.5em,
+  'large': 64em
 );

--- a/src/scss/layout/_body.scss
+++ b/src/scss/layout/_body.scss
@@ -1,5 +1,31 @@
 @use 'abstracts' as *;
 
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
 body {
+  padding: 0 rem(40px);
   font-family: $font__roboto;
+  background-color: $color__gray-400;
+}
+
+.container {
+  width: 100%;
+  max-width: $size__container-max-width;
+  margin-right: auto;
+  margin-left: auto;
+
+  &--inner {
+    width: 100%;
+    max-width: $size__container-max-width--inner;
+    margin-right: auto;
+    margin-left: auto;
+  }
 }

--- a/src/scss/layout/_body.scss
+++ b/src/scss/layout/_body.scss
@@ -11,9 +11,14 @@ html {
 }
 
 body {
-  padding: 0 rem(40px);
+  padding: 0 rem(24px);
   font-family: $font__roboto;
   background-color: $color__gray-400;
+
+  @include breakpoint('medium') {
+    padding-right: rem(40px);
+    padding-left: rem(40px);
+  }
 }
 
 .container {

--- a/src/shared/site-config/Footer.js
+++ b/src/shared/site-config/Footer.js
@@ -7,7 +7,7 @@ const Footer = () => {
   }
 
   return (
-    <footer className="site-footer">
+    <footer className="site-footer container">
       <section className="site-footer__about">
         <section className="site-footer__content">
           <div className="site-footer__logo">

--- a/src/shared/site-config/Introduction.js
+++ b/src/shared/site-config/Introduction.js
@@ -16,7 +16,7 @@ const Introduction = () => {
   }
 
   return (
-    <section className="intro">
+    <section className="intro container--inner">
       <div className="intro__program">{program_name}</div>
       <h1 className="intro__subject">{subject}</h1>
       <div>{intro_paragraph}</div>

--- a/src/shared/site-config/Methodology.js
+++ b/src/shared/site-config/Methodology.js
@@ -7,10 +7,10 @@ const Methodology = () => {
   const { methodology, program_description } = siteInfo
 
   return (
-    <section id="methodology" className="site-footer__explanation">
-      <h2 className="site-footer__title">Methodology</h2>
-      <p className="site-footer__methodology">{methodology}</p>
-      <p className="site-footer__prog-desc">{program_description}</p>
+    <section id="methodology" className="methodology container--inner">
+      <h2 className="methodology__title">Methodology</h2>
+      <p className="methodology__desc">{methodology}</p>
+      <p className="methodology__program-desc">{program_description}</p>
     </section>
   )
 }

--- a/src/shared/table-options/TableOptions.js
+++ b/src/shared/table-options/TableOptions.js
@@ -55,7 +55,7 @@ const TableOptions = () => {
   }
 
   return (
-    <section className="table__options">
+    <section className="table__options container">
       <SearchFilter
         handleFilter={handleFilter}
         searchText={searchText}


### PR DESCRIPTION
This PR adds padding to either side of the body. It also creates two container classes, `.container` and `.container--inner` that add a max width of 1200px and 980px, respectively. These classes were applied to the relevant components (Intro, Table Options, Methodology, and Footer).

Note that by adding these container classes, pseudo elements will need to be used to expand the background of the footer and the border for the header.

This PR should not be merged in until #62 has been merged into `master`.