### PR TITLE
Add reusable button component styles

### DIFF
--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -1,0 +1,142 @@
+@use 'abstracts' as *;
+
+.btn {
+  @extend %button;
+  display: inline-block;
+  padding: rem(8px) rem(16px);
+  text-align: center;
+  background-color: transparent;
+  border: 0;
+  border-radius: 2px;
+  transition: all 0.3s ease-in-out;
+
+  &:focus {
+    outline: 2px solid $color__blue-200;
+  }
+
+  &:not([disabled]) {
+    cursor: pointer;
+  }
+
+  &[disabled] {
+    cursor: not-allowed;
+  }
+
+  &.btn--xs {
+    @extend %body__text-xs;
+  }
+
+  &.btn--square {
+    padding: rem(8px);
+  }
+
+  &.btn--primary {
+    color: $color__white-190;
+    text-transform: uppercase;
+    background: $color__blue-400;
+
+    &:not([disabled]):hover {
+      background: $color__blue-600;
+    }
+
+    &[disabled] {
+      background: $color__gray-430;
+    }
+  }
+
+  &.btn--dark {
+    color: $color__white-190;
+    text-transform: uppercase;
+    background: $color__gray-600;
+
+    &:hover {
+      color: $color__white;
+      background: $color__gray-500;
+    }
+
+    &.js-isActive {
+      background: $color__gray-400;
+      border: 2px solid $color__blue-300;
+
+      &:hover {
+        border-color: #85b7db;
+      }
+    }
+  }
+
+  &.btn--white {
+    position: relative;
+    color: $color__gray-300;
+    background: rgba($color__white, 0.85);
+    border: solid 1px $color__white-125;
+    box-shadow: inset 0 1px 2px 0 rgba(102, 113, 123, 0.21),
+      inset 0 0 0 1px rgba(102, 113, 123, 0.25);
+
+    // Apply outer box-shadow to a pseudo element for performance reasons. More info here: https://alligator.io/css/transition-box-shadows/
+    &::before {
+      content: ' ';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.21);
+      opacity: 0;
+      transition: opacity 0.3s ease-in-out;
+    }
+
+    &:hover::before {
+      opacity: 1;
+    }
+  }
+
+  &.btn--transparent-light,
+  &.btn--transparent-dark {
+    padding: rem(8px);
+  }
+
+  &.btn--transparent {
+    &-light {
+      color: $color__gray-460;
+
+      &:hover {
+        color: $color__black;
+      }
+    }
+
+    &-dark {
+      color: $color__white-160;
+
+      &:hover {
+        color: $color__white;
+      }
+    }
+  }
+
+  &.btn--icon {
+    display: inline-flex;
+    align-items: center;
+
+    .icon {
+      margin-right: rem(8px);
+    }
+  }
+
+  // These get their own class because they don't follow any of the above patterns entirely.
+  &.btn--scroll {
+    display: inline-flex;
+    align-items: center;
+    color: $color__white-190;
+    @include font-size(18px);
+    background: transparent;
+
+    &:not([disabled]):hover {
+      color: $color__white;
+      background: $color__gray-600;
+    }
+
+    &[disabled] {
+      color: $color__white-130;
+    }
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -2,6 +2,7 @@
 
 /* Import Styles */
 
-@use 'components/table';
 @use 'vendors/normalize';
+@use 'components/buttons';
+@use 'components/table';
 @use 'layout/body';

--- a/src/shared/table-options/ScrollBar.js
+++ b/src/shared/table-options/ScrollBar.js
@@ -33,11 +33,17 @@ const ScrollBar = () => {
 
   return (
     <div className="table__scroll">
-      <button className="scroll-btn" onClick={scrollLeft}>
-        <Icon icon={'arrow_chev_left'} />
+      <button
+        className="scroll-btn btn btn--scroll btn--square"
+        onClick={scrollLeft}
+      >
+        <Icon icon={'arrow-chev-left'} />
       </button>
-      <button className="scroll-btn" onClick={scrollRight}>
-        <Icon icon={'arrow_chev_right'} />
+      <button
+        className="scroll-btn btn btn--scroll btn--square"
+        onClick={scrollRight}
+      >
+        <Icon icon={'arrow-chev-right'} />
       </button>
     </div>
   )


### PR DESCRIPTION
This adds several reusable button styles that can be used throughout the site. They're designed to be modular, so a single button could have several button classes applied. Below is a list of which buttons should have what classes.

Note that these buttons can be furthered styled with specific classes, but the button classes are meant to ensure consistent styling across the site.

- "Filter Button" - `btn btn--dark btn--icon` (it should also have `.js-isActive` added when filters are applied)
- "Filter Button Reset" - `btn btn--transparent-dark btn--xs btn--icon`
- "Font Resize Buttons" - `btn btn--dark btn--square` (the active button should have `.js-isActive` applied)
- "Scroll Buttons" - These already have their classes applied, but they have their own class because they don't follow the existing patterns (`.btn btn--scroll`). Note that these buttons should have the `disabled` property applied if the user can't scroll in that direction.
- "Modal Close Button" - `btn btn--transparent-light`
- "Modal Filter Button" - `btn btn--white btn--square`
- "Modal Apply Button" - `btn btn--primary` (note that this button should have the `disabled` property apply if no rows/columns are selected)
- "Modal Reset all filters button" - `btn btn--transparent-light btn--xs btn--icon`
