### PR TITLE
Add hover effect on table cell & show OG language button

### DIFF
--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -11,7 +11,7 @@ $color__white-160: rgba(255, 255, 255, 0.6);
 $color__white-175: rgba(255, 255, 255, 0.75);
 $color__white-190: rgba(255, 255, 255, 0.9);
 
-$color__highlight-row: rgba(232, 238, 242, 0.6);
+$color__highlight-row: #f1f5f7;
 $color__highlight-cell: #e6ebef;
 
 $color__blue-100: #b4d3e9;

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -63,9 +63,21 @@
       color: $color__gray-300;
       @extend %body__text-m;
       background-color: $color__white;
+      transition: background 0.3s ease-in-out;
 
       &:first-child {
+        z-index: 5;
         box-shadow: 0 6px 8px 0 rgba(164, 164, 164, 0.5);
+        pointer-events: none;
+      }
+
+      .cell__orig-lang {
+        opacity: 0;
+        transition: all 0.3s ease-in-out;
+      }
+
+      .icon {
+        transition: none;
       }
     }
 
@@ -83,7 +95,30 @@
   }
 
   &__row {
+    background-color: $color__white;
     border-bottom: solid 1px $color__gray-200;
+    pointer-events: none;
+
+    > *:not(.table__cell--collection) {
+      pointer-events: auto;
+    }
+
+    &:hover,
+    &:focus-within {
+      > * {
+        background: $color__highlight-row;
+      }
+
+      > :hover,
+      > :focus {
+        background: $color__highlight-cell;
+
+        /* stylelint-disable-next-line */
+        .cell__orig-lang {
+          opacity: 1;
+        }
+      }
+    }
   }
 
   .header-cell {

--- a/src/shared/table/TableCell.js
+++ b/src/shared/table/TableCell.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import Icon from '../site-config/Icon'
 import { GlobalContext } from '../../context/GlobalContext'
 
 const TableCell = (props) => {
@@ -25,7 +26,11 @@ const TableCell = (props) => {
 
   const renderOriginalLang = () => {
     return catObj.original_lang !== '' ? (
-      <button className="cell__orig-lang" onClick={handleClick}>
+      <button
+        className="btn btn--transparent-light btn--xs btn--icon cell__orig-lang"
+        onClick={handleClick}
+      >
+        <Icon icon={'eye'} />
         View Original Language
       </button>
     ) : null


### PR DESCRIPTION
Close #36 

This adds the table cell hover effect, where hovering over a cell changes the background color of that cell and the rest of the row. You actually can't target previous siblings with CSS, so this effect is accomplished with a trick that involves hovering on the parent. You can read more about it in [this article](https://www.trysmudford.com/blog/fade-out-siblings-css-trick/). I did have to go 4 levels deep for nesting in order to get the original language button to appear, so I ignored that stylelint rule for this specific case.

The other thing I had to change was the hex code for the `$color__higlight-row` variable. In the mockups, that color had an opacity lower than 1. This meant that scrolling horizontally on the table resulted in the body cells being visible behind the first cell in the row. Because of how the CSS limitations of implementing an effect like this, I switched it to a very similar gray color with full opacity.