### PR TITLE
Feat/collections filter func

### DIFF
--- a/src/shared/modals/custom-filter/CollectionsFilter.js
+++ b/src/shared/modals/custom-filter/CollectionsFilter.js
@@ -9,7 +9,8 @@ const CollectionsFilter = (props) => {
     setCheckedCollections,
     collectionsMenu,
     allRows,
-    collections
+    collections,
+    setDisplayedRows
   } = props
 
   return (
@@ -30,6 +31,7 @@ const CollectionsFilter = (props) => {
               allRows={allRows}
               setCheckedCollections={setCheckedCollections}
               checkedCollections={checkedCollections}
+              setDisplayedRows={setDisplayedRows}
               key={i}
               name={c}
             ></CollectionsItem>

--- a/src/shared/modals/custom-filter/CollectionsItem.js
+++ b/src/shared/modals/custom-filter/CollectionsItem.js
@@ -1,15 +1,45 @@
 import React from 'react'
 
 const CollectionsItem = (props) => {
-  const { name, checkedCollections, setCheckedCollections, allRows } = props
+  const {
+    name,
+    checkedCollections,
+    setCheckedCollections,
+    allRows,
+    setDisplayedRows
+  } = props
 
   // Toggles collection item's checked status on user input
   const handleChange = () => {
     if (!checkedCollections.includes(name)) {
       setCheckedCollections([...checkedCollections, name])
+      updateRows(isValidCheck)
     } else {
       setCheckedCollections(checkedCollections.filter((col) => col !== name))
+      updateRows(isValidUncheck)
     }
+  }
+
+  // Helper f(n) that checks condition for adding collection to active filters
+  const isValidCheck = (cat) => {
+    return name === cat || checkedCollections.includes(cat)
+  }
+
+  // Helper f(n) that checks condition for removing collection from active filters
+  const isValidUncheck = (cat) => {
+    return name !== cat && checkedCollections.includes(cat)
+  }
+
+  // Updates displayed rows to reflect change in collection filter
+  const updateRows = (valid) => {
+    setDisplayedRows(
+      allRows.reduce((acc, row) => {
+        if (valid(row[1][1].category)) {
+          acc.push(row[0][0])
+        }
+        return acc
+      }, [])
+    )
   }
 
   const collectionCount = (name) => {
@@ -18,8 +48,17 @@ const CollectionsItem = (props) => {
 
   return (
     <div className="checkbox__container">
-      <input  type="checkbox" value={name} name="collections" id={name} onChange={handleChange} checked={checkedCollections.includes(name)}/>
-      <label className="checkbox__items" htmlFor={name}>{name}</label>
+      <input
+        type="checkbox"
+        value={name}
+        name="collections"
+        id={name}
+        onChange={handleChange}
+        checked={checkedCollections.includes(name)}
+      />
+      <label className="checkbox__items" htmlFor={name}>
+        {name}
+      </label>
 
       <span className="modal__col-count-item">
         {collectionCount(name)}&nbsp;items

--- a/src/shared/modals/custom-filter/FilterModal.js
+++ b/src/shared/modals/custom-filter/FilterModal.js
@@ -161,6 +161,7 @@ const FilterModal = () => {
           allRows={allRows}
           checkedCollections={checkedCollections}
           setCheckedCollections={setCheckedCollections}
+          setDisplayedRows={setDisplayedRows}
         />
       </section>
       <FilterFooter

--- a/src/shared/modals/custom-filter/FilterModal.js
+++ b/src/shared/modals/custom-filter/FilterModal.js
@@ -29,6 +29,12 @@ const FilterModal = () => {
     // eslint-disable-next-line
   }, [allRows, allHeaders])
 
+  useEffect(() => {
+    if (checkedCollections.length === 0) {
+      setDisplayedRows(allRows.map((row) => row[0][0]))
+    }
+  }, [checkedCollections])
+
   const onClose = () => {
     setFilterModalStatus(false)
   }

--- a/src/shared/modals/custom-filter/FilterModal.js
+++ b/src/shared/modals/custom-filter/FilterModal.js
@@ -1,6 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react'
 import { GlobalContext } from '../../../context/GlobalContext'
-import { uniq } from 'lodash'
 import ModalHeader from '../ModalHeader'
 import FilterTabs from './FilterTabs'
 import FilterFooter from './FilterFooter'
@@ -29,6 +28,7 @@ const FilterModal = () => {
     // eslint-disable-next-line
   }, [allRows, allHeaders])
 
+  // Condition for resetting displayedRows when no collections are checked
   useEffect(() => {
     if (checkedCollections.length === 0) {
       setDisplayedRows(allRows.map((row) => row[0][0]))
@@ -113,23 +113,20 @@ const FilterModal = () => {
   const applyRowFilters = () => {
     setFilteredRows(
       sortRows(
-        uniq([
-          ...allRows.filter(
+        allRows
+          .filter(
             (row) =>
               checkedRows.includes(row[0][0]) &&
               displayedRows.includes(row[0][0])
-          ),
-          ...allRows.filter((row) =>
-            checkedCollections.includes(row[1][1].category)
           )
-        ]).map((row) => {
-          return row.filter(
-            (r) =>
-              (checkedColumns.includes(r[0]) &&
-                displayedColumns.includes(r[0])) ||
-              typeof r[1] === 'string'
-          )
-        })
+          .map((row) => {
+            return row.filter(
+              (r) =>
+                (checkedColumns.includes(r[0]) &&
+                  displayedColumns.includes(r[0])) ||
+                typeof r[1] === 'string'
+            )
+          })
       )
     )
   }

--- a/src/shared/modals/custom-filter/FilterPanel.js
+++ b/src/shared/modals/custom-filter/FilterPanel.js
@@ -13,7 +13,8 @@ const FilterPanel = (props) => {
     setCheckedCollections,
     title,
     maxItems,
-    displayedItems
+    displayedItems,
+    setDisplayedRows
   } = props
 
   // resets filter on tab change
@@ -57,6 +58,8 @@ const FilterPanel = (props) => {
         collections={collections}
         handleClick={handleClick}
         collectionsMenu={collectionsMenu}
+        displayedItems={displayedItems}
+        setDisplayedRows={setDisplayedRows}
       />
 
       {renderItemsCount()}

--- a/src/shared/modals/custom-filter/FilterPanel.js
+++ b/src/shared/modals/custom-filter/FilterPanel.js
@@ -17,12 +17,6 @@ const FilterPanel = (props) => {
     setDisplayedRows
   } = props
 
-  // resets filter on tab change
-  useEffect(() => {
-    handleSearchFilter('', title)
-    // eslint-disable-next-line
-  }, [])
-
   const handleInput = (e) => {
     handleSearchFilter(e.target.value, title)
   }

--- a/src/shared/modals/custom-filter/FilterTabs.js
+++ b/src/shared/modals/custom-filter/FilterTabs.js
@@ -23,7 +23,8 @@ const FilterTabs = (props) => {
     collections,
     allRows,
     checkedCollections,
-    setCheckedCollections
+    setCheckedCollections,
+    setDisplayedRows
   } = props
 
   return (
@@ -49,6 +50,7 @@ const FilterTabs = (props) => {
           title={'Columns'}
           displayedItems={displayedColumns}
           maxItems={maxColumns}
+          setDisplayedRows={setDisplayedRows}
         />
 
         <FilterSelect
@@ -74,6 +76,7 @@ const FilterTabs = (props) => {
           title={'Rows'}
           displayedItems={displayedRows}
           maxItems={maxRows}
+          setDisplayedRows={setDisplayedRows}
         />
 
         <FilterSelect


### PR DESCRIPTION
- Updated collections filter functionality
- Additional logic required because the data in the collections filter (eg definitions) did not match the data in the displayedRows (data controller). 
- The isValidChecked and isValidUnchecked helper f(n)'s were necessary for handling async actions with adding and removing from checkedCollections 
- Remove old collections filter code
- Add reset condition for displaying rows when a user does not check a collection