### PR TITLE
Change transition on modal to use transforms & toggle visibility

### DIFF
--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -22,7 +22,9 @@
   max-width: 500px;
   background: $color__white;
   box-shadow: 0 6px 8px 0 rgba(44, 8, 8, 0.5);
-  transition: all 0.6s ease-in-out;
+  transform: translateX(0);
+  visibility: visible;
+  transition: visibility 0.6s linear, transform 0.6s ease-in-out;
 
   a {
     color: $color__blue-400;
@@ -35,7 +37,8 @@
   }
 
   &--hidden {
-    right: -500px;
+    transform: translateX(100%);
+    visibility: hidden;
   }
 
   &__header,


### PR DESCRIPTION
I've updated the transition on the modals to do two things differently:

1. Rather than transitioning the "right" property, I'm using a transform on the placement instead. It is always better to transition a transform over one of the positions (top, right, bottom, left) because it doesn't require the browser to redraw. Transforming it 100% ensures that the entire element will be off screen.

2. I've also added a visibility property, which should ensure that when the modal is positioned off screen, it isn't visible (even if Lindsay scrolls really far to the side 😄)

Let me know if you have any questions about this!