### PR TITLE
Adjust 100vw measurement to take into account scrollbars

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import RouteContainer from './RouteContainer'
+import { setScrollbarWidth } from './scrollbar'
 
 function App() {
+  setScrollbarWidth()
+
   return (
     <div className="App">
       <RouteContainer />

--- a/src/app/scrollbar.js
+++ b/src/app/scrollbar.js
@@ -1,0 +1,34 @@
+// Calculates the width of the user's scrollbar to modify the 100vw value in CSS.
+// Taken from: https://codepen.io/Mamboleoo/post/scrollbars-and-css-custom-properties
+
+const getScrollbarWidth = () => {
+  // Create a temporary div container and append it into the body
+  const container = document.createElement('div')
+  // Append the container in the body
+  document.body.appendChild(container)
+  // Force scrollbar on the container
+  container.style.overflow = 'scroll'
+
+  // Add ad fake div inside the container
+  const inner = document.createElement('div')
+  container.appendChild(inner)
+
+  // Calculate the width based on the container width minus its child width
+  const width = container.offsetWidth - inner.offsetWidth
+  // Remove the container from the body
+  document.body.removeChild(container)
+
+  return width
+}
+
+const setScrollbarWidth = () => {
+  // Get the scrollbar dimension
+  const scrollbarWidth = getScrollbarWidth()
+  // Set a custom property with the value we calculated
+  document.documentElement.style.setProperty(
+    '--scrollbar',
+    `${scrollbarWidth}px`
+  )
+}
+
+export { setScrollbarWidth }

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -47,3 +47,8 @@
   font-size: $size; //Fallback in px
   font-size: rem($size);
 }
+
+@mixin vw100() {
+  width: 100vw; // Fallback for old browsers
+  width: calc(100vw - var(--scrollbar));
+}

--- a/src/scss/components/_methodology.scss
+++ b/src/scss/components/_methodology.scss
@@ -17,7 +17,7 @@
     top: 0;
     left: calc((100vw - 100%) / -2);
     display: block;
-    width: 100vw;
+    @include vw100;
     height: 1px;
     background-color: $color__gray-700;
     opacity: 0.37;

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -3,10 +3,10 @@
 .modal__overlay {
   position: fixed;
   top: 0;
+  right: 0;
+  bottom: 0;
   left: 0;
   z-index: 10;
-  width: 100vw;
-  height: 100vh;
   background-color: rgba(0, 0, 0, 0.5);
 }
 

--- a/src/scss/layout/_body.scss
+++ b/src/scss/layout/_body.scss
@@ -3,6 +3,10 @@
 $padding--mobile: 24px;
 $padding--desktop: 40px;
 
+:root {
+  --scrollbar: 0;
+}
+
 html {
   box-sizing: border-box;
 }

--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -18,7 +18,7 @@
     left: calc((100vw - 100%) / -2);
     z-index: -1;
     display: block;
-    width: 100vw;
+    @include vw100;
     height: 100%;
     background-color: $color__gray-500;
   }

--- a/src/scss/layout/_header.scss
+++ b/src/scss/layout/_header.scss
@@ -14,7 +14,7 @@
     bottom: 0;
     left: calc((100vw - 100%) / -2);
     display: block;
-    width: 100vw;
+    @include vw100;
     height: 1px;
     background-color: $color__gray-700;
     opacity: 0.37;


### PR DESCRIPTION
One of the drawbacks to using vw & vh units is that they don't take into account scrollbars. I read [an article](https://codepen.io/Mamboleoo/post/scrollbars-and-css-custom-properties) over the weekend that proposed how to use CSS variables to account for that by calculating the size of the scrollbar with JavaScript and subtracting that value from `100vw`. I applied it in a few places here.

@smaraghi, I wasn't sure if this was the right place to include this bit of JS. If it isn't, please feel free to move it so it follows best practices for file organization/structure.