### PR TITLE
Sticky Table Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ $ npm install
 $ npm start
 ```
 
+## Version
+
+Note that this project uses React v16.9 and should **not** be updated until the [React Scroll Sync](https://github.com/okonet/react-scroll-sync) plugin has been updated to use new lifecycle hooks.
+
 ## Usage
 
 ### Local Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -11959,6 +11959,11 @@
         }
       }
     },
+    "react-scroll-sync": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.7.0.tgz",
+      "integrity": "sha512-PL4MWceh596EA+z5zLPYYB7HfctjShh+XTOZ5FgZnxwA66g1Fnx0kK0DMjma23cqlhXBvYLA7Fnp67afzBwdHA=="
+    },
     "react-tabs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",
+    "react-scroll-sync": "^0.7.0",
     "react-tabs": "^3.0.0",
     "react-transition-group": "^4.3.0",
     "sass": "^1.23.0",

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -1,11 +1,6 @@
 @use 'abstracts' as *;
 
 .table {
-  --font-size--sm: 1;
-  --font-size--md: 1.1;
-  --font-size--lg: 1.2;
-  --table-font-size: var(--font-size--sm);
-
   flex: 1 1 auto;
   width: 100%;
   text-align: left;

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -6,7 +6,7 @@
   --font-size--lg: 1.2;
   --table-font-size: var(--font-size--sm);
 
-  flex: 1 1;
+  flex: 1 1 auto;
   width: 100%;
   text-align: left;
   table-layout: fixed;
@@ -17,8 +17,6 @@
     position: relative;
     display: flex;
     max-width: 100%;
-    /* height must be set for the header to be sticky */
-    height: 100vh;
     overflow: scroll;
 
     &::after {
@@ -28,26 +26,45 @@
       width: 2rem;
       height: 100%;
     }
+
+    &--sticky {
+      position: sticky;
+      top: 65px;
+      top: calc(var(--optionsHeight) - 1px);
+      z-index: 10;
+    }
+  }
+
+  col {
+    width: 200px;
+
+    @include breakpoint('large') {
+      width: 250px;
+    }
+
+    &:first-child {
+      width: 150px;
+
+      @include breakpoint('large') {
+        width: 300px;
+      }
+    }
   }
 
   &__cell {
-    width: 200px;
     padding: 1rem;
     vertical-align: top;
-    
+
     @include breakpoint('large') {
-      width: 250px;
       padding: rem(24px);
     }
 
     &:first-child {
       position: sticky;
       left: 0;
-      width: 150px;
       padding-left: 1rem;
 
       @include breakpoint('large') {
-        width: 300px;
         padding-left: rem(40px);
       }
     }
@@ -57,8 +74,7 @@
     }
 
     &--header {
-      position: sticky;
-      top: 0;
+      position: relative;
       z-index: 1;
       color: $color__white;
       font-weight: 500;
@@ -253,14 +269,32 @@
   }
 
   &__options {
+    position: sticky;
+    top: -1px;
+    z-index: 15;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: rem(28px);
+    padding: rem(24px) 0;
 
     @include breakpoint('large') {
       flex-wrap: nowrap;
+    }
+
+    &--sticky {
+      background-color: $color__gray-400;
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: calc((100vw - 100%) / -2);
+        z-index: -1;
+        display: block;
+        @include vw100;
+        height: 100%;
+        background-color: $color__gray-400;
+      }
     }
 
     &-spacer {
@@ -307,7 +341,7 @@
   }
 }
 
-@supports(-ms-ime-align:auto) {
+@supports (-ms-ime-align: auto) {
   .table {
     border-collapse: separate;
 

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -12,7 +12,7 @@
     position: relative;
     display: flex;
     max-width: 100%;
-    overflow: scroll;
+    overflow-x: scroll;
 
     &::after {
       content: '';

--- a/src/scss/layout/_body.scss
+++ b/src/scss/layout/_body.scss
@@ -5,6 +5,7 @@ $padding--desktop: 40px;
 
 :root {
   --scrollbar: 0;
+  --optionsHeight: 0;
 }
 
 html {

--- a/src/scss/layout/_body.scss
+++ b/src/scss/layout/_body.scss
@@ -6,6 +6,10 @@ $padding--desktop: 40px;
 :root {
   --scrollbar: 0;
   --optionsHeight: 0;
+  --font-size--sm: 1;
+  --font-size--md: 1.1;
+  --font-size--lg: 1.2;
+  --table-font-size: var(--font-size--sm);
 }
 
 html {

--- a/src/shared/table-options/FontResize.js
+++ b/src/shared/table-options/FontResize.js
@@ -6,8 +6,7 @@ const FontResize = () => {
 
   const resize = (size) => {
     setActiveSize(size)
-    let table = document.getElementById('table')
-    table.style.setProperty(
+    document.documentElement.style.setProperty(
       '--table-font-size',
       'var(--font-size--' + size + ')'
     )

--- a/src/shared/table-options/TableOptions.js
+++ b/src/shared/table-options/TableOptions.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { GlobalContext } from '../../context/GlobalContext'
 import SearchFilter from './SearchFilter'
 import FontResize from './FontResize'
@@ -23,6 +23,8 @@ const TableOptions = () => {
     setLangModalStatus,
     customFilteredRows
   } = useContext(GlobalContext)
+
+  const [isSticky, setIsSticky] = useState(false)
 
   const filterByCategories = (rows, text) => {
     return rows.filter((row) =>
@@ -68,8 +70,26 @@ const TableOptions = () => {
     }
   }
 
+  useEffect(() => {
+    const options = document.getElementById('table__options')
+    const height = options.getBoundingClientRect().height
+    document.documentElement.style.setProperty('--optionsHeight', `${height}px`)
+
+    const observer = new IntersectionObserver(
+      ([e]) => setIsSticky(e.intersectionRatio < 1),
+      { threshold: [1] }
+    )
+
+    observer.observe(options)
+  }, [])
+
+  const className = 'table__options container'
+
   return (
-    <section className="table__options container">
+    <section
+      id="table__options"
+      className={className + (isSticky ? ' table__options--sticky' : '')}
+    >
       <div className="table__options-spacer">
         <SearchFilter
           handleFilter={handleFilter}

--- a/src/shared/table-options/TableOptions.js
+++ b/src/shared/table-options/TableOptions.js
@@ -75,12 +75,14 @@ const TableOptions = () => {
     const height = options.getBoundingClientRect().height
     document.documentElement.style.setProperty('--optionsHeight', `${height}px`)
 
-    const observer = new IntersectionObserver(
-      ([e]) => setIsSticky(e.intersectionRatio < 1),
-      { threshold: [1] }
-    )
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(
+        ([e]) => setIsSticky(e.intersectionRatio < 1),
+        { threshold: [1] }
+      )
 
-    observer.observe(options)
+      observer.observe(options)
+    }
   }, [])
 
   const className = 'table__options container'

--- a/src/shared/table/DataTable.js
+++ b/src/shared/table/DataTable.js
@@ -74,11 +74,6 @@ const DataTable = (props) => {
           <div id="table-container" className="table__container">
             <table id="table" className="table">
               <colgroup>{headers.map(renderColRow)}</colgroup>
-              {/* <thead>
-                <tr className="table__header-row">
-                  {headers.map(renderHeadingRow)}
-                </tr>
-              </thead> */}
               {rows.length > 0 ? (
                 <tbody>{rows.map(renderRow)}</tbody>
               ) : (

--- a/src/shared/table/DataTable.js
+++ b/src/shared/table/DataTable.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import HeaderCell from './HeaderCell'
 import TableCell from './TableCell'
+import { ScrollSync, ScrollSyncPane } from 'react-scroll-sync'
 
 const DataTable = (props) => {
   const { headers, rows } = props
+
+  const renderColRow = (cell, cellIndex) => {
+    return <col key={cellIndex}></col>
+  }
 
   const renderHeadingRow = (cell, cellIndex) => {
     const { headers, rows } = props
@@ -48,20 +53,44 @@ const DataTable = (props) => {
   }
 
   return (
-    <div id="table-container" className="table__container">
-      <table id="table" className="table">
-        <thead>
-          <tr className="table__header-row">{headers.map(renderHeadingRow)}</tr>
-        </thead>
-        {rows.length > 0 ? (
-          <tbody>{rows.map(renderRow)}</tbody>
-        ) : (
-          <tbody>
-            <tr>{renderSearchErr()}</tr>
-          </tbody>
-        )}
-      </table>
-    </div>
+    <ScrollSync>
+      <div>
+        <ScrollSyncPane>
+          <div
+            className="table__container table__container--sticky"
+            aria-hidden="true"
+          >
+            <table id="table-copy" className="table">
+              <colgroup>{headers.map(renderColRow)}</colgroup>
+              <thead>
+                <tr className="table__header-row">
+                  {headers.map(renderHeadingRow)}
+                </tr>
+              </thead>
+            </table>
+          </div>
+        </ScrollSyncPane>
+        <ScrollSyncPane>
+          <div id="table-container" className="table__container">
+            <table id="table" className="table">
+              <colgroup>{headers.map(renderColRow)}</colgroup>
+              {/* <thead>
+                <tr className="table__header-row">
+                  {headers.map(renderHeadingRow)}
+                </tr>
+              </thead> */}
+              {rows.length > 0 ? (
+                <tbody>{rows.map(renderRow)}</tbody>
+              ) : (
+                <tbody>
+                  <tr>{renderSearchErr()}</tr>
+                </tbody>
+              )}
+            </table>
+          </div>
+        </ScrollSyncPane>
+      </div>
+    </ScrollSync>
   )
 }
 

--- a/src/shared/table/HeaderCell.js
+++ b/src/shared/table/HeaderCell.js
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react'
 import Icon from '../site-config/Icon'
 import { GlobalContext } from '../../context/GlobalContext'
-import Tippy from '@tippy.js/react';
-import 'tippy.js/dist/tippy.css';
-import 'tippy.js/themes/light.css';
+import Tippy from '@tippy.js/react'
+import 'tippy.js/dist/tippy.css'
+import 'tippy.js/themes/light.css'
 
 const HeaderCell = (props) => {
   const {
@@ -30,16 +30,17 @@ const HeaderCell = (props) => {
   }
 
   return name === 'Categories' ? (
-  
-    <th className="table__cell table__cell--header">Categories</th>
+    <th className="table__cell table__cell--header" scope="col">
+      Categories
+    </th>
   ) : (
     <th className={handleSearchErr()} scope="col">
-     <Tippy content={<span>{name}</span>} placement="top" theme="light">
-      <button className="header-cell__title" onClick={handleClick}>
-        {name}
-        <Icon handleClick={null} icon={'info'} />
-      </button>
-      </Tippy> 
+      <Tippy content={<span>{name}</span>} placement="top" theme="light">
+        <button className="header-cell__title" onClick={handleClick}>
+          {name}
+          <Icon handleClick={null} icon={'info'} />
+        </button>
+      </Tippy>
       <p className="header-cell__org">{organization}</p>
       <a className="header-cell__doc-link" href={url}>
         <Icon icon={'external-link'} />


### PR DESCRIPTION
This fixes the sticky table headers by separating out the header row into its own table. They are linked together by the ScrollSync plugin, which ensures that scrolling horizontally will scroll both tables together.

- To account for the table widths, a `colgroup` was added to both tables
- An observer was added that checks when the options are stickied & a background color is added (otherwise you'd see the table through it)
- I moved all the CSS variables to the `:root` selector so they would apply to both tables
- I attempted to use Hooks without really understanding how they work, so if there's a better way to do this, then by all means please let me know.